### PR TITLE
Offshoot#50 crc cards

### DIFF
--- a/MotherTreeCrafts/Docs/Analysis/crc-cards.md
+++ b/MotherTreeCrafts/Docs/Analysis/crc-cards.md
@@ -9,7 +9,7 @@ Connections and relationships open to change and feedback
 #### Product
 Responsibilities:
 - Holds information relating to a product
-- Holds product status
+- Holds product stock status (in stock, out of stock, discontinued, etc.)
 
 Collaborators:
 - Inventory


### PR DESCRIPTION
Closes #50 

This pull request introduces a new documentation file outlining the class relationships and responsibilities for the project using CRC (Class-Responsibility-Collaborator) cards. The page serves as a reference and planning tool for future refactoring and reviews.

Documentation and planning:

* Added a CRC card analysis page (`MotherTreeCrafts/Docs/Analysis/crc-cards.md`) detailing the responsibilities and collaborators for the main classes: `Product`, `Inventory`, `ProductReview`, `Wishlist`, and `UserAccount`.
* Provided guidance that the document will be updated as the project evolves, and invited feedback on class relationships.