### PR TITLE
Offshoot #70 - adjusting email

### DIFF
--- a/MotherTreeCrafts/Migrations/20260315203859_AddedNewPropertyToUser.Designer.cs
+++ b/MotherTreeCrafts/Migrations/20260315203859_AddedNewPropertyToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MotherTreeCrafts.Data;
 
@@ -11,9 +12,11 @@ using MotherTreeCrafts.Data;
 namespace MotherTreeCrafts.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315203859_AddedNewPropertyToUser")]
+    partial class AddedNewPropertyToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MotherTreeCrafts/Migrations/20260315203859_AddedNewPropertyToUser.cs
+++ b/MotherTreeCrafts/Migrations/20260315203859_AddedNewPropertyToUser.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MotherTreeCrafts.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedNewPropertyToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailAddress",
+                table: "AspNetUsers");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailAddress",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/MotherTreeCrafts/Models/UserAccount.cs
+++ b/MotherTreeCrafts/Models/UserAccount.cs
@@ -32,11 +32,6 @@ public class UserAccount : IdentityUser
     public string? BillingAddress { get; set; }
 
     /// <summary>
-    /// User's email address for order management
-    /// </summary>
-    public string? EmailAddress { get; set; }
-
-    /// <summary>
     /// Collection of wishlist items for this account
     /// </summary>
     public ICollection<Wishlist> WishlistItems { get; set; } = new List<Wishlist>();

--- a/MotherTreeCrafts/Program.cs
+++ b/MotherTreeCrafts/Program.cs
@@ -19,8 +19,12 @@ builder.Services.Configure<AuthMessageSenderOptions>(builder.Configuration);
 // Register our custom EmailSender
 builder.Services.AddTransient<IEmailSender, EmailSender>();
 
-// Ensure that Identity requires confirmed accounts 
-builder.Services.AddDefaultIdentity<UserAccount>(options => options.SignIn.RequireConfirmedAccount = true)
+// Ensure that Identity requires confirmed accounts and unique emails
+builder.Services.AddDefaultIdentity<UserAccount>(options => 
+    {
+        options.SignIn.RequireConfirmedAccount = true;
+        options.User.RequireUniqueEmail = true; // Prevent duplicate emails
+    })
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 


### PR DESCRIPTION
Closes #70 

Removed the custom EmailAddress property from the UserAccount model and database schema. Updated Identity configuration to require unique emails using the built-in Email property. Added migration to drop the EmailAddress column and updated EF Core model snapshot to version 10.0.5. This standardizes email handling and enforces uniqueness at the application level.